### PR TITLE
Modernize `tox.ini`.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,6 @@ deps =
 commands =
     make clean
     make html SPHINXOPTS=-W
-whitelist_externals =
+allowlist_externals =
     make
 


### PR DESCRIPTION
A must since tox4 and available since v3.18.0.